### PR TITLE
added PreviousObservations to enable history and currentobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: julia
 
 julia:
-  - 0.7
   - 1.0
+  - 1
 
 os:
   - linux

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BeliefUpdaters"
 uuid = "8bb6e9a1-7d73-552c-a44a-e5dc5634aac4"
-version = "0.1.2"
+version = "0.2.0"
 
 [deps]
 POMDPModelTools = "08074719-1b2a-587c-a292-00f91cc44415"
@@ -10,7 +10,8 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-julia = "≥ 0.7.0"
+POMDPs = "0.7.3, 0.8"
+julia = "1"
 
 [extras]
 POMDPModels = "355abbd5-f08e-5560-ac9e-8b5f2592a0ca"

--- a/test/test_k_previous_observations_belief.jl
+++ b/test/test_k_previous_observations_belief.jl
@@ -42,6 +42,7 @@ bp = update(up, b, rand(rng, actions(pomdp)), o)
 @test bp[end] == o
 @test length(bp) == up.k == 5
 @test bp[1:end-1] == fill(o0, length(bp)-1)
+@test history(bp)[end].o == currentobs(bp)
 
 # check that b is unchanged
 @test b == initialize_belief(up, fill(o0, up.k))


### PR DESCRIPTION
This is the only change needed to be compatible with v0.8

@MaximeBouton was it ok to introduce this new type? I thought `currentobs(::AbstractVector)` and `history(::AbstractVector)` were too broad.